### PR TITLE
Check the user facing release combination regularly

### DIFF
--- a/.github/workflows/tests-dev.yml
+++ b/.github/workflows/tests-dev.yml
@@ -27,3 +27,31 @@ jobs:
 
       - name: Run tests against MDAnalysis dev version
         run: tox -e tests-dev
+
+  tests-release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check out latest release tag
+        run: git checkout $(git describe --tags --abbrev=0)
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install released scatterkit and test dependencies
+        run: |
+          python -m pip install scatterkit
+          python -m pip install -r tests/requirements.txt
+          python -m pip list
+
+      - name: Run tests against released versions
+        run: pytest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ CHANGELOG file
   - keep the format consistent (79 char width, Y/M/D date format) and do not
     use tabs but use spaces for formatting
 
-Unreleased
-----------
+v0.1.1 (2026/05/12)
+-------------------
 Henrik Stooß
 
 - Removed versioneer and switched to setuptools_scm for version management (#16)


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

partially adresses #19 

Changes made in this Pull Request:
 - Run a weekly check if scatterkit can still be run from release

PR Checklist
------------
 - [ ] Docs?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview scatterkit start -->
----
📚 Documentation preview 📚: https://scatterkit--21.org.readthedocs.build/en/21/

<!-- readthedocs-preview scatterkit end -->